### PR TITLE
Await result before first async iteration in 3.5.2+ in SQL alchemy execute

### DIFF
--- a/aiopg/utils.py
+++ b/aiopg/utils.py
@@ -86,7 +86,20 @@ class _SAConnectionContextManager(_ContextManager):
     if PY_35:  # pragma: no branch
         if PY_352:
             def __aiter__(self):
-                return self._coro
+                return self
+
+            @asyncio.coroutine
+            def __anext__(self):
+                if self._obj is None:
+                    self._obj = yield from self._coro
+
+                try:
+                    return (yield from self._obj.__anext__())
+                except StopAsyncIteration:
+                    self._obj.close()
+                    self._obj = None
+                    raise
+
         else:
             @asyncio.coroutine
             def __aiter__(self):

--- a/tests/pep492/test_async_await.py
+++ b/tests/pep492/test_async_await.py
@@ -1,12 +1,9 @@
-import sys
 import asyncio
 import pytest
 import psycopg2
 import aiopg
 import aiopg.sa
 from aiopg.sa import SAConnection
-
-PY_37 = sys.version_info >= (3, 7)
 
 
 @asyncio.coroutine
@@ -278,10 +275,7 @@ async def test_sa_connection_execute(pg_params, loop):
     result = []
     async with aiopg.sa.create_engine(loop=loop, **pg_params) as engine:
         async with engine.acquire() as conn:
-            rows = conn.execute(sql)
-            if PY_37:
-                rows = await rows
-            async for value in rows:
+            async for value in conn.execute(sql):
                 result.append(value)
             assert result == [(1,), (2, ), (3, ), (4, ), (5, )]
     assert conn.closed


### PR DESCRIPTION
Our post-3.5.2 code was triggering CPython's pre-3.5.2 backwards compatibility given that ProxyResult isn't awaited before it is iterated. This fix makes `_SAConnectionContextManager` act as the iterator, wrapping the ProxyResult iterator so the ProxyResult can be awaited prior to the first iteration.