### PR TITLE
Fix for RuntimeError in Python 3.7+ from unexpected StopIteration raises

### DIFF
--- a/aiopg/cursor.py
+++ b/aiopg/cursor.py
@@ -384,7 +384,7 @@ class Cursor:
         while True:
             row = yield from self.fetchone()
             if row is None:
-                raise StopIteration
+                return
             else:
                 yield row
 

--- a/aiopg/sa/result.py
+++ b/aiopg/sa/result.py
@@ -335,7 +335,7 @@ class ResultProxy:
         while True:
             row = yield from self.fetchone()
             if row is None:
-                raise StopIteration
+                return
             else:
                 yield row
 


### PR DESCRIPTION
The behavior of iteration has changed to where a StopIteration exception should not be raised inside a generator except by something unexpected. See [PEP 479](https://www.python.org/dev/peps/pep-0479/) for details.

This supplements PR aio-libs/aiopg#437 for issue aio-libs/aiopg#436.