### PR TITLE
Allow QA of StopAsyncIteration lines, give flake8 built-ins hint in Python <3.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ pep:
 	pep8 aiopg examples tests
 
 flake:
-	extra=$$(python -c "import sys;sys.stdout.write('--exclude tests/pep492') if sys.version_info[:3] < (3, 5, 0) else sys.stdout.write('examples')"); \
+	extra=$$(python -c "import sys;sys.stdout.write('--exclude tests/pep492 --builtins=StopAsyncIteration') if sys.version_info[:3] < (3, 5, 0) else sys.stdout.write('examples')"); \
 	flake8 aiopg tests $$extra
 
 test: flake

--- a/aiopg/cursor.py
+++ b/aiopg/cursor.py
@@ -402,7 +402,7 @@ class Cursor:
             if ret is not None:
                 return ret
             else:
-                raise StopAsyncIteration  # noqa
+                raise StopAsyncIteration
 
         @asyncio.coroutine
         def __aenter__(self):

--- a/aiopg/sa/result.py
+++ b/aiopg/sa/result.py
@@ -353,7 +353,7 @@ class ResultProxy:
             if ret is not None:
                 return ret
             else:
-                raise StopAsyncIteration  # noqa
+                raise StopAsyncIteration
 
     def _non_result(self):
         if self._metadata is None:


### PR DESCRIPTION
Resolves Python 3.4 flake8 continuous integration failure caused by Python 3.7 compatibility changes.